### PR TITLE
Fix temp file leak in run importer

### DIFF
--- a/server/import_runs.py
+++ b/server/import_runs.py
@@ -56,12 +56,15 @@ def main():
             inner_ext = lower[:-3].split('.')[-1]  # 'fit' or 'gpx'
             with gzip.open(path, 'rb') as f_in:
                 tf = tempfile.NamedTemporaryFile(suffix='.' + inner_ext, delete=False)
-                tf.write(f_in.read())
-                tf.close()
-            if inner_ext == 'fit':
-                coords = parse_fit(tf.name)
-            else:
-                coords = parse_gpx(tf.name)
+                try:
+                    tf.write(f_in.read())
+                    tf.close()
+                    if inner_ext == 'fit':
+                        coords = parse_fit(tf.name)
+                    else:
+                        coords = parse_gpx(tf.name)
+                finally:
+                    os.unlink(tf.name)
 
         # uncompressed .fit
         elif lower.endswith('.fit'):


### PR DESCRIPTION
## Summary
- ensure gzip extractions clean up temporary files

## Testing
- `python3 -m py_compile server/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6856bded2dac8321964baf73c341e7ad