### PR TITLE
Add progress bar to import_runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A local, interactive heatmap of your GPS runs—powered by Flask, MapLibre GL JS
    python import_runs.py
    ```
 
-   You should see:
+  The script shows a progress bar while processing files. When finished you should see:
 
    ```
    Imported <N> runs → runs.pkl

--- a/server/import_runs.py
+++ b/server/import_runs.py
@@ -5,6 +5,7 @@ import tempfile
 from shapely.geometry import LineString
 import gpxpy
 from fitdecode import FitReader, FitDataMessage
+from tqdm import tqdm
 
 RAW_DIR = os.path.join(os.path.dirname(__file__), '..', 'data', 'raw')
 OUTPUT_PKL = os.path.join(os.path.dirname(__file__), 'runs.pkl')
@@ -43,7 +44,10 @@ def main():
     runs = []
     rid = 0
 
-    for fname in os.listdir(RAW_DIR):
+    files = [f for f in os.listdir(RAW_DIR)
+             if os.path.isfile(os.path.join(RAW_DIR, f))]
+
+    for fname in tqdm(files, desc="Processing", unit="file"):
         path = os.path.join(RAW_DIR, fname)
         if not os.path.isfile(path):
             continue
@@ -94,3 +98,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,3 +3,5 @@ gpxpy
 fitdecode
 shapely
 rtree
+
+tqdm


### PR DESCRIPTION
## Summary
- display progress while importing runs
- document the progress bar usage
- add tqdm dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856c00fc758832195d944e4ec1d9beb