### PR TITLE
Fix FIT import error for missing position fields

### DIFF
--- a/server/import_runs.py
+++ b/server/import_runs.py
@@ -29,8 +29,12 @@ def parse_fit(path):
         for frame in fit:
             if not isinstance(frame, FitDataMessage) or frame.name != 'record':
                 continue
-            raw_lat = frame.get_value('position_lat')
-            raw_lon = frame.get_value('position_long')
+            try:
+                raw_lat = frame.get_value('position_lat')
+                raw_lon = frame.get_value('position_long')
+            except KeyError:
+                # Skip records that don't include position fields
+                continue
             if raw_lat is None or raw_lon is None:
                 continue
             # convert semicircles → degrees


### PR DESCRIPTION
## Summary
- ignore FIT record messages that lack positional data

## Testing
- `python -m py_compile server/import_runs.py`

------
https://chatgpt.com/codex/tasks/task_e_6856e561381883218ff6d42ebf1b8c21