### PR TITLE
Add server-side progress output

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,6 +1,7 @@
-import pickle
+mport pickle
 from flask import Flask, request, jsonify, send_from_directory
 from shapely.geometry import box, mapping
+from tqdm import tqdm
 
 # Load runs and build spatial index
 with open('runs.pkl', 'rb') as f:
@@ -29,6 +30,10 @@ def get_runs():
     ids = list(idx.intersection((minLng, minLat, maxLng, maxLat)))
 
     print(f"🔍 Candidate run IDs for bbox ({minLat:.3f},{minLng:.3f})→({maxLat:.3f},{maxLng:.3f}): {ids}")
+    print(
+        f"🔍 Candidate run IDs for bbox ({minLat:.3f},{minLng:.3f})→({maxLat:.3f},{maxLng:.3f}): {ids}"
+    )
+    print(f"↪ Processing {len(ids)} runs at zoom {zoom}")
 
     # choose pre-simplified geometry based on zoom level
     if zoom >= 13:
@@ -40,14 +45,26 @@ def get_runs():
 
     features = []
     for rid in ids:
+    minx, miny, maxx, maxy = bbox.bounds
+    for rid in tqdm(ids, desc="runs", unit="run"):
         run = runs[rid]
         line = run['geoms'][key]
         clipped = line.intersection(bbox)
         if clipped.is_empty:
             continue
+        rb = run['bbox']
+        # if run is fully contained in the bbox, avoid expensive intersection
+        if rb[0] >= minx and rb[1] >= miny and rb[2] <= maxx and rb[3] <= maxy:
+            geom = line
+        else:
+            clipped = line.intersection(bbox)
+            if clipped.is_empty:
+                continue
+            geom = clipped
         features.append({
             'type': 'Feature',
             'geometry': mapping(clipped),
+            'geometry': mapping(geom),
             'properties': {}
         })
 


### PR DESCRIPTION
## Summary
- show progress in /api/runs by using tqdm
- log number of candidate runs

https://chatgpt.com/codex/tasks/task_e_6856f8aafe2083219b1f3002de0494fb