### PR TITLE
Improve server performance with caching

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -15,11 +15,32 @@
       width: 100%;
       height: 100%;
     }
+
+    /* progress bar container */
+    #progress-container {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      width: 160px;
+      height: 8px;
+      background: rgba(255, 255, 255, 0.8);
+      border: 1px solid #aaa;
+      display: none;
+    }
+
+    /* bar itself */
+    #progress-bar {
+      background: #007bff;
+      width: 0%;
+      height: 100%;
+      transition: width 0.2s ease;
+    }
   </style>
 </head>
 
 <body>
   <div id="map"></div>
+  <div id="progress-container"><div id="progress-bar"></div></div>
   <script>
     // initialize an “empty” style so we can add our own sources/layers
     const map = new maplibregl.Map({
@@ -74,14 +95,43 @@
       fetchAndUpdate();
     });
 
+    const progressContainer = document.getElementById('progress-container');
+    const progressBar = document.getElementById('progress-bar');
+
+    function showProgress() {
+      progressContainer.style.display = 'block';
+      progressBar.style.width = '0%';
+    }
+
+    function updateProgress(pct) {
+      progressBar.style.width = pct + '%';
+    }
+
+    function hideProgress() {
+      progressContainer.style.display = 'none';
+    }
+
     // fetch & update function (expects to be defined in main.js)
     function fetchAndUpdate() {
       const b = map.getBounds();
       const z = Math.floor(map.getZoom());
       const url = `/api/runs?minLat=${b.getSouth()}&minLng=${b.getWest()}&maxLat=${b.getNorth()}&maxLng=${b.getEast()}&zoom=${z}`;
-      fetch(url)
-        .then(r => r.json())
-        .then(data => map.getSource('runs').setData(data));
+      const xhr = new XMLHttpRequest();
+      xhr.open('GET', url);
+      xhr.responseType = 'json';
+      xhr.onprogress = (e) => {
+        if (e.lengthComputable) {
+          const pct = Math.round((e.loaded / e.total) * 100);
+          updateProgress(pct);
+        }
+      };
+      xhr.onload = () => {
+        hideProgress();
+        map.getSource('runs').setData(xhr.response);
+      };
+      xhr.onerror = hideProgress;
+      showProgress();
+      xhr.send();
     }
 
     // re-fetch on moveend


### PR DESCRIPTION
## Summary
- cache geojson slices in `server/app.py`
- show progress bar while requesting map data

## Testing
- `python3 -m py_compile server/app.py server/import_runs.py`


------
https://chatgpt.com/codex/tasks/task_e_6857028b58708321a75a5a3258f57132