### PR TITLE
Improve server performance with caching

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -15,11 +15,41 @@
       width: 100%;
       height: 100%;
     }
+
+    /* progress bars */
+    #progress-container {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      width: 160px;
+      display: none;
+    }
+
+    .progress {
+      width: 100%;
+      height: 8px;
+      background: rgba(255, 255, 255, 0.8);
+      border: 1px solid #aaa;
+      margin-top: 4px;
+      position: relative;
+    }
+
+    .progress:first-child {
+      margin-top: 0;
+    }
+
+    .progress-bar {
+      background: #007bff;
+      width: 0%;
+      height: 100%;
+      transition: width 0.2s ease;
+    }
   </style>
 </head>
 
 <body>
   <div id="map"></div>
+  <div id="progress-container"></div>
   <script>
     // initialize an “empty” style so we can add our own sources/layers
     const map = new maplibregl.Map({
@@ -74,14 +104,48 @@
       fetchAndUpdate();
     });
 
+    const progressContainer = document.getElementById('progress-container');
+
+    function createProgress() {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'progress';
+      const bar = document.createElement('div');
+      bar.className = 'progress-bar';
+      wrapper.appendChild(bar);
+      progressContainer.appendChild(wrapper);
+      progressContainer.style.display = 'block';
+      return { wrapper, bar };
+    }
+
+    function removeProgress(wrapper) {
+      progressContainer.removeChild(wrapper);
+      if (progressContainer.children.length === 0) {
+        progressContainer.style.display = 'none';
+      }
+    }
+
     // fetch & update function (expects to be defined in main.js)
     function fetchAndUpdate() {
       const b = map.getBounds();
       const z = Math.floor(map.getZoom());
       const url = `/api/runs?minLat=${b.getSouth()}&minLng=${b.getWest()}&maxLat=${b.getNorth()}&maxLng=${b.getEast()}&zoom=${z}`;
-      fetch(url)
-        .then(r => r.json())
-        .then(data => map.getSource('runs').setData(data));
+
+      const { wrapper, bar } = createProgress();
+      const xhr = new XMLHttpRequest();
+      xhr.open('GET', url);
+      xhr.responseType = 'json';
+      xhr.onprogress = (e) => {
+        if (e.lengthComputable) {
+          const pct = Math.round((e.loaded / e.total) * 100);
+          bar.style.width = pct + '%';
+        }
+      };
+      xhr.onload = () => {
+        removeProgress(wrapper);
+        map.getSource('runs').setData(xhr.response);
+      };
+      xhr.onerror = () => removeProgress(wrapper);
+      xhr.send();
     }
 
     // re-fetch on moveend


### PR DESCRIPTION
## Summary
- cache geojson slices in `server/app.py`
- show progress bar while requesting map data
- allow multiple concurrent progress bars

## Testing
- `python3 -m py_compile server/app.py server/import_runs.py`


------
https://chatgpt.com/codex/tasks/task_e_6857028b58708321a75a5a3258f57132