### PR TITLE
Improve map performance and add SSE progress

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,6 +1,8 @@
 import pickle
+import json
+import time
 from functools import lru_cache
-from flask import Flask, request, jsonify, send_from_directory
+from flask import Flask, request, jsonify, send_from_directory, Response, stream_with_context
 from shapely.geometry import box, mapping
 from tqdm import tqdm
 
@@ -20,13 +22,12 @@ def root():
     return send_from_directory(app.static_folder, 'index.html')
 
 
-def quantize(val, digits=4):
+def quantize(val, digits=3):
     """Round coordinate for caching stability."""
     return round(val, digits)
 
 
-@lru_cache(maxsize=512)
-def _runs_for_bbox(minLat, minLng, maxLat, maxLng, zoom):
+def _compute_runs(minLat, minLng, maxLat, maxLng, zoom, progress_cb=None):
     bbox = box(minLng, minLat, maxLng, maxLat)
     ids = list(idx.intersection((minLng, minLat, maxLng, maxLat)))
 
@@ -45,7 +46,8 @@ def _runs_for_bbox(minLat, minLng, maxLat, maxLng, zoom):
 
     features = []
     minx, miny, maxx, maxy = bbox.bounds
-    for rid in tqdm(ids, desc="runs", unit="run"):
+    total = len(ids)
+    for i, rid in enumerate(tqdm(ids, desc="runs", unit="run"), 1):
         run = runs[rid]
         line = run['geoms'][key]
         rb = run['bbox']
@@ -62,9 +64,16 @@ def _runs_for_bbox(minLat, minLng, maxLat, maxLng, zoom):
             'geometry': mapping(geom),
             'properties': {}
         })
+        if progress_cb:
+            progress_cb(int(i * 100 / total))
 
     print(f"→ Returning {len(features)} features")
     return {'type': 'FeatureCollection', 'features': features}
+
+
+@lru_cache(maxsize=2048)
+def _runs_for_bbox(minLat, minLng, maxLat, maxLng, zoom):
+    return _compute_runs(minLat, minLng, maxLat, maxLng, zoom)
 
 @app.route('/api/runs')
 def get_runs():
@@ -76,6 +85,60 @@ def get_runs():
 
     data = _runs_for_bbox(minLat, minLng, maxLat, maxLng, zoom)
     return jsonify(data)
+
+
+@app.route('/api/stream_runs')
+def stream_runs():
+    minLat = quantize(float(request.args.get('minLat')))
+    minLng = quantize(float(request.args.get('minLng')))
+    maxLat = quantize(float(request.args.get('maxLat')))
+    maxLng = quantize(float(request.args.get('maxLng')))
+    zoom = int(request.args.get('zoom'))
+
+    def generate():
+        bbox = box(minLng, minLat, maxLng, maxLat)
+        ids = list(idx.intersection((minLng, minLat, maxLng, maxLat)))
+
+        print(
+            f"🔍 Candidate run IDs for bbox ({minLat:.3f},{minLng:.3f})→({maxLat:.3f},{maxLng:.3f}): {ids}"
+        )
+        print(f"↪ Processing {len(ids)} runs at zoom {zoom}")
+
+        if zoom >= 13:
+            key = 'full'
+        elif zoom >= 10:
+            key = 'mid'
+        else:
+            key = 'coarse'
+
+        features = []
+        minx, miny, maxx, maxy = bbox.bounds
+        total = len(ids)
+        for i, rid in enumerate(tqdm(ids, desc="runs", unit="run"), 1):
+            run = runs[rid]
+            line = run['geoms'][key]
+            rb = run['bbox']
+            if rb[0] >= minx and rb[1] >= miny and rb[2] <= maxx and rb[3] <= maxy:
+                geom = line
+            else:
+                clipped = line.intersection(bbox)
+                if clipped.is_empty:
+                    continue
+                geom = clipped
+            features.append({
+                'type': 'Feature',
+                'geometry': mapping(geom),
+                'properties': {}
+            })
+
+            yield f"event: progress\ndata: {int(i*100/total)}\n\n"
+
+        print(f"→ Returning {len(features)} features")
+        data = {'type': 'FeatureCollection', 'features': features}
+        yield f"event: data\ndata: {json.dumps(data)}\n\n"
+
+    headers = {'Cache-Control': 'no-cache'}
+    return Response(stream_with_context(generate()), headers=headers, mimetype='text/event-stream')
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/web/index.html
+++ b/web/index.html
@@ -125,40 +125,37 @@
 
     function fetchAndUpdate() {
       if (activeRequest) {
-        activeRequest.xhr.abort();
+        activeRequest.es.close();
+        removeProgress(activeRequest.wrapper);
+        activeRequest = null;
       }
 
       const b = map.getBounds();
       const z = Math.floor(map.getZoom());
-      const url = `/api/runs?minLat=${b.getSouth()}&minLng=${b.getWest()}&maxLat=${b.getNorth()}&maxLng=${b.getEast()}&zoom=${z}`;
+      const url = `/api/stream_runs?minLat=${b.getSouth()}&minLng=${b.getWest()}&maxLat=${b.getNorth()}&maxLng=${b.getEast()}&zoom=${z}`;
 
       const { wrapper, bar } = createProgress();
-      const xhr = new XMLHttpRequest();
-      activeRequest = { xhr, wrapper };
-
-      xhr.open('GET', url);
-      xhr.responseType = 'json';
-      xhr.onprogress = (e) => {
-        if (e.lengthComputable) {
-          const pct = Math.round((e.loaded / e.total) * 100);
-          bar.style.width = pct + '%';
-        }
-      };
+      const es = new EventSource(url);
+      activeRequest = { es, wrapper };
 
       const finalize = () => {
         removeProgress(wrapper);
-        if (activeRequest && activeRequest.xhr === xhr) {
+        if (activeRequest && activeRequest.es === es) {
           activeRequest = null;
         }
+        es.close();
       };
 
-      xhr.onload = () => {
+      es.addEventListener('progress', (e) => {
+        bar.style.width = e.data + '%';
+      });
+
+      es.addEventListener('data', (e) => {
+        map.getSource('runs').setData(JSON.parse(e.data));
         finalize();
-        map.getSource('runs').setData(xhr.response);
-      };
-      xhr.onerror = finalize;
-      xhr.onabort = finalize;
-      xhr.send();
+      });
+
+      es.onerror = finalize;
     }
 
     map.on('moveend', fetchAndUpdate);


### PR DESCRIPTION
## Summary
- improve caching by quantizing to 3 digits and increasing LRU cache size
- add `/api/stream_runs` endpoint that streams progress updates
- connect the client progress bar to server progress using EventSource

## Testing
- `python3 -m py_compile server/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6857f6a5f0f08321a42bbd120d7090ce