### PR TITLE
Improve client map caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ map.addLayer({
 
 * **Adding new runs**: Drop new `.gpx`/`.fit.gz` files into `data/raw/` then re-run step 1.
 * **Rebuilding data**: No external tile build—server streams GeoJSON slices on demand.
-* **Performance**: The importer precomputes simplified geometries for multiple zoom levels. The server uses these along with an R-tree spatial index so panning and zooming stay responsive. The front-end caches data for a slightly larger area than is visible and refreshes it whenever the zoom level changes, so panning around nearby remains instant without sacrificing detail when zooming.
+* **Performance**: The importer precomputes simplified geometries for multiple zoom levels. The server uses these along with an R-tree spatial index so panning and zooming stay responsive. The front-end keeps a few recent views cached per zoom level, prefetching a larger region at high zooms. This lets quick zoom-ins and outs reuse existing data instantly.
 
 Enjoy exploring your run history!

--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ map.addLayer({
 
 * **Adding new runs**: Drop new `.gpx`/`.fit.gz` files into `data/raw/` then re-run step 1.
 * **Rebuilding data**: No external tile build—server streams GeoJSON slices on demand.
-* **Performance**: The importer precomputes simplified geometries for multiple zoom levels. The server uses these along with an R-tree spatial index so panning and zooming stay responsive. The front-end keeps a few recent views cached per zoom level, prefetching a larger region at high zooms. This lets quick zoom-ins and outs reuse existing data instantly.
+* **Performance**: The importer precomputes simplified geometries for multiple zoom levels. The server uses these along with an R-tree spatial index so panning and zooming stay responsive. The front-end keeps a few recent views cached per zoom level and prefetches a 10+ mile region around the map center at street zooms. The cached area recenters as you pan so new spots load in the background for smoother exploring.
 
 Enjoy exploring your run history!

--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ map.addLayer({
 
 * **Adding new runs**: Drop new `.gpx`/`.fit.gz` files into `data/raw/` then re-run step 1.
 * **Rebuilding data**: No external tile build—server streams GeoJSON slices on demand.
-* **Performance**: The importer precomputes simplified geometries for multiple zoom levels. The server uses these along with an R-tree spatial index so panning and zooming stay responsive.
+* **Performance**: The importer precomputes simplified geometries for multiple zoom levels. The server uses these along with an R-tree spatial index so panning and zooming stay responsive. The front-end also caches data for a slightly larger area than is visible so that short pans don't require additional requests.
 
 Enjoy exploring your run history!

--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ map.addLayer({
 
 * **Adding new runs**: Drop new `.gpx`/`.fit.gz` files into `data/raw/` then re-run step 1.
 * **Rebuilding data**: No external tile build—server streams GeoJSON slices on demand.
-* **Performance**: The importer precomputes simplified geometries for multiple zoom levels. The server uses these along with an R-tree spatial index so panning and zooming stay responsive. The front-end also caches data for a slightly larger area than is visible so that short pans don't require additional requests.
+* **Performance**: The importer precomputes simplified geometries for multiple zoom levels. The server uses these along with an R-tree spatial index so panning and zooming stay responsive. The front-end caches data for a slightly larger area than is visible and refreshes it whenever the zoom level changes, so panning around nearby remains instant without sacrificing detail when zooming.
 
 Enjoy exploring your run history!

--- a/web/index.html
+++ b/web/index.html
@@ -124,6 +124,7 @@
     let activeRequest = null;
     let cachedBounds = null;
     let cachedData = null;
+    let cachedZoom = null;
 
     function withinBounds(outer, inner) {
       return (
@@ -142,8 +143,9 @@
       }
 
       const view = map.getBounds();
+      const z = Math.floor(map.getZoom());
 
-      if (cachedBounds && withinBounds(cachedBounds, view)) {
+      if (cachedBounds && cachedZoom === z && withinBounds(cachedBounds, view)) {
         map.getSource('runs').setData(cachedData);
         return;
       }
@@ -155,7 +157,6 @@
       const minLng = view.getWest() - lngExt;
       const maxLat = view.getNorth() + latExt;
       const maxLng = view.getEast() + lngExt;
-      const z = Math.floor(map.getZoom());
       const url = `/api/stream_runs?minLat=${minLat}&minLng=${minLng}&maxLat=${maxLat}&maxLng=${maxLng}&zoom=${z}`;
 
       const { wrapper, bar } = createProgress();
@@ -178,6 +179,7 @@
         const data = JSON.parse(e.data);
         cachedBounds = new maplibregl.LngLatBounds([minLng, minLat], [maxLng, maxLat]);
         cachedData = data;
+        cachedZoom = z;
         map.getSource('runs').setData(data);
         finalize();
       });

--- a/web/index.html
+++ b/web/index.html
@@ -122,6 +122,17 @@
     }
 
     let activeRequest = null;
+    let cachedBounds = null;
+    let cachedData = null;
+
+    function withinBounds(outer, inner) {
+      return (
+        inner.getSouth() >= outer.getSouth() &&
+        inner.getNorth() <= outer.getNorth() &&
+        inner.getWest() >= outer.getWest() &&
+        inner.getEast() <= outer.getEast()
+      );
+    }
 
     function fetchAndUpdate() {
       if (activeRequest) {
@@ -130,9 +141,22 @@
         activeRequest = null;
       }
 
-      const b = map.getBounds();
+      const view = map.getBounds();
+
+      if (cachedBounds && withinBounds(cachedBounds, view)) {
+        map.getSource('runs').setData(cachedData);
+        return;
+      }
+
+      const margin = 0.25;
+      const latExt = (view.getNorth() - view.getSouth()) * margin;
+      const lngExt = (view.getEast() - view.getWest()) * margin;
+      const minLat = view.getSouth() - latExt;
+      const minLng = view.getWest() - lngExt;
+      const maxLat = view.getNorth() + latExt;
+      const maxLng = view.getEast() + lngExt;
       const z = Math.floor(map.getZoom());
-      const url = `/api/stream_runs?minLat=${b.getSouth()}&minLng=${b.getWest()}&maxLat=${b.getNorth()}&maxLng=${b.getEast()}&zoom=${z}`;
+      const url = `/api/stream_runs?minLat=${minLat}&minLng=${minLng}&maxLat=${maxLat}&maxLng=${maxLng}&zoom=${z}`;
 
       const { wrapper, bar } = createProgress();
       const es = new EventSource(url);
@@ -151,7 +175,10 @@
       });
 
       es.addEventListener('data', (e) => {
-        map.getSource('runs').setData(JSON.parse(e.data));
+        const data = JSON.parse(e.data);
+        cachedBounds = new maplibregl.LngLatBounds([minLng, minLat], [maxLng, maxLat]);
+        cachedData = data;
+        map.getSource('runs').setData(data);
         finalize();
       });
 

--- a/web/index.html
+++ b/web/index.html
@@ -122,9 +122,9 @@
     }
 
     let activeRequest = null;
-    let cachedBounds = null;
-    let cachedData = null;
-    let cachedZoom = null;
+    const caches = {}; // zoom -> {bounds, data}
+    const cacheOrder = [];
+    const MAX_CACHES = 3;
 
     function withinBounds(outer, inner) {
       return (
@@ -133,6 +133,36 @@
         inner.getWest() >= outer.getWest() &&
         inner.getEast() <= outer.getEast()
       );
+    }
+
+    function getCached(view, zoom) {
+      const levels = Object.keys(caches)
+        .map((z) => parseInt(z, 10))
+        .sort((a, b) => b - a);
+      for (const z of levels) {
+        const entry = caches[z];
+        if (z >= zoom && withinBounds(entry.bounds, view)) {
+          return entry.data;
+        }
+      }
+      return null;
+    }
+
+    function storeCache(zoom, bounds, data) {
+      caches[zoom] = { bounds, data };
+      const idx = cacheOrder.indexOf(zoom);
+      if (idx !== -1) cacheOrder.splice(idx, 1);
+      cacheOrder.unshift(zoom);
+      if (cacheOrder.length > MAX_CACHES) {
+        const old = cacheOrder.pop();
+        delete caches[old];
+      }
+    }
+
+    function marginForZoom(z) {
+      if (z >= 13) return 1.0;
+      if (z >= 11) return 0.5;
+      return 0.25;
     }
 
     function fetchAndUpdate() {
@@ -145,12 +175,13 @@
       const view = map.getBounds();
       const z = Math.floor(map.getZoom());
 
-      if (cachedBounds && cachedZoom === z && withinBounds(cachedBounds, view)) {
-        map.getSource('runs').setData(cachedData);
+      const cached = getCached(view, z);
+      if (cached) {
+        map.getSource('runs').setData(cached);
         return;
       }
 
-      const margin = 0.25;
+      const margin = marginForZoom(z);
       const latExt = (view.getNorth() - view.getSouth()) * margin;
       const lngExt = (view.getEast() - view.getWest()) * margin;
       const minLat = view.getSouth() - latExt;
@@ -177,9 +208,8 @@
 
       es.addEventListener('data', (e) => {
         const data = JSON.parse(e.data);
-        cachedBounds = new maplibregl.LngLatBounds([minLng, minLat], [maxLng, maxLat]);
-        cachedData = data;
-        cachedZoom = z;
+        const bounds = new maplibregl.LngLatBounds([minLng, minLat], [maxLng, maxLat]);
+        storeCache(z, bounds, data);
         map.getSource('runs').setData(data);
         finalize();
       });

--- a/web/index.html
+++ b/web/index.html
@@ -126,6 +126,9 @@
     const cacheOrder = [];
     const MAX_CACHES = 3;
 
+    let lastCenter = null;
+    let lastZoom = null;
+
     function withinBounds(outer, inner) {
       return (
         inner.getSouth() >= outer.getSouth() &&
@@ -160,7 +163,8 @@
     }
 
     function marginForZoom(z) {
-      if (z >= 13) return 1.0;
+      if (z >= 15) return 4.0;
+      if (z >= 13) return 2.0;
       if (z >= 11) return 0.5;
       return 0.25;
     }
@@ -175,9 +179,21 @@
       const view = map.getBounds();
       const z = Math.floor(map.getZoom());
 
+      const center = map.getCenter();
       const cached = getCached(view, z);
       if (cached) {
         map.getSource('runs').setData(cached);
+      }
+
+      const latSpan = view.getNorth() - view.getSouth();
+      const lngSpan = view.getEast() - view.getWest();
+      const centerMoved =
+        !lastCenter ||
+        Math.abs(center.lat - lastCenter.lat) > latSpan * 0.2 ||
+        Math.abs(center.lng - lastCenter.lng) > lngSpan * 0.2 ||
+        z !== lastZoom;
+
+      if (!centerMoved && cached) {
         return;
       }
 
@@ -211,6 +227,8 @@
         const bounds = new maplibregl.LngLatBounds([minLng, minLat], [maxLng, maxLat]);
         storeCache(z, bounds, data);
         map.getSource('runs').setData(data);
+        lastCenter = center;
+        lastZoom = z;
         finalize();
       });
 

--- a/web/main.js
+++ b/web/main.js
@@ -8,6 +8,7 @@ const map = new maplibregl.Map({
 let activeController = null;
 let cachedBounds = null;
 let cachedData = null;
+let cachedZoom = null;
 
 function withinBounds(outer, inner) {
   return (
@@ -34,8 +35,9 @@ map.on('load', () => {
 
 function fetchAndUpdate() {
   const view = map.getBounds();
+  const z = Math.floor(map.getZoom());
 
-  if (cachedBounds && withinBounds(cachedBounds, view)) {
+  if (cachedBounds && cachedZoom === z && withinBounds(cachedBounds, view)) {
     map.getSource('runs').setData(cachedData);
     return;
   }
@@ -47,7 +49,6 @@ function fetchAndUpdate() {
   const minLng = view.getWest() - lngExt;
   const maxLat = view.getNorth() + latExt;
   const maxLng = view.getEast() + lngExt;
-  const z = Math.floor(map.getZoom());
   const url = `/api/runs?minLat=${minLat}&minLng=${minLng}&maxLat=${maxLat}&maxLng=${maxLng}&zoom=${z}`;
 
   if (activeController) {
@@ -60,6 +61,7 @@ function fetchAndUpdate() {
     .then(data => {
       cachedBounds = new maplibregl.LngLatBounds([minLng, minLat], [maxLng, maxLat]);
       cachedData = data;
+      cachedZoom = z;
       map.getSource('runs').setData(data);
     })
     .catch(err => {


### PR DESCRIPTION
## Summary
- cache map data on the client for a larger area
- reuse cached data while panning to cut down requests
- document the client-side cache in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68585e52e7cc8321a83d506248874aab