### PR TITLE
Improve run clipping performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ map.addLayer({
 
 * **Adding new runs**: Drop new `.gpx`/`.fit.gz` files into `data/raw/` then re-run step 1.
 * **Rebuilding data**: No external tile build—server streams GeoJSON slices on demand.
-* **Performance**: The importer precomputes simplified geometries for multiple zoom levels. The server uses these along with an R-tree spatial index so panning and zooming stay responsive.
+* **Performance**: The importer precomputes simplified geometries for multiple zoom levels. The server uses these along with an R-tree spatial index and fast bounding box clipping so panning and zooming stay responsive even with dense data.
 
 Enjoy exploring your run history!


### PR DESCRIPTION
## Summary
- drop shapely `box` polygon creation
- clip lines with `clip_by_rect`
- note fast clipping in README

## Testing
- `python -m py_compile server/app.py server/import_runs.py`
- `python server/import_runs.py`

------
https://chatgpt.com/codex/tasks/task_e_68586863bd9c8321a19f5d9a451b06a1