### PR TITLE
Stream lines during SSE loading

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -110,7 +110,6 @@ def stream_runs():
         else:
             key = 'coarse'
 
-        features = []
         minx, miny, maxx, maxy = minLng, minLat, maxLng, maxLat
         total = len(ids)
         for i, rid in enumerate(tqdm(ids, desc="runs", unit="run"), 1):
@@ -124,17 +123,16 @@ def stream_runs():
                 if clipped.is_empty:
                     continue
                 geom = clipped
-            features.append({
+            feature = {
                 'type': 'Feature',
                 'geometry': mapping(geom),
                 'properties': {}
-            })
+            }
 
+            yield f"event: feature\ndata: {json.dumps(feature)}\n\n"
             yield f"event: progress\ndata: {int(i*100/total)}\n\n"
 
-        print(f"→ Returning {len(features)} features")
-        data = {'type': 'FeatureCollection', 'features': features}
-        yield f"event: data\ndata: {json.dumps(data)}\n\n"
+        yield "event: done\ndata: end\n\n"
 
     headers = {'Cache-Control': 'no-cache'}
     return Response(stream_with_context(generate()), headers=headers, mimetype='text/event-stream')

--- a/web/index.html
+++ b/web/index.html
@@ -122,6 +122,7 @@
     }
 
     let activeRequest = null;
+    let currentFeatures = [];
 
     function fetchAndUpdate() {
       if (activeRequest) {
@@ -138,6 +139,9 @@
       const es = new EventSource(url);
       activeRequest = { es, wrapper };
 
+      currentFeatures = [];
+      map.getSource('runs').setData({ type: 'FeatureCollection', features: [] });
+
       const finalize = () => {
         removeProgress(wrapper);
         if (activeRequest && activeRequest.es === es) {
@@ -150,10 +154,12 @@
         bar.style.width = e.data + '%';
       });
 
-      es.addEventListener('data', (e) => {
-        map.getSource('runs').setData(JSON.parse(e.data));
-        finalize();
+      es.addEventListener('feature', (e) => {
+        currentFeatures.push(JSON.parse(e.data));
+        map.getSource('runs').setData({ type: 'FeatureCollection', features: currentFeatures });
       });
+
+      es.addEventListener('done', finalize);
 
       es.onerror = finalize;
     }

--- a/web/index.html
+++ b/web/index.html
@@ -141,6 +141,16 @@
 
       currentFeatures = [];
       map.getSource('runs').setData({ type: 'FeatureCollection', features: [] });
+      let updateScheduled = false;
+
+      function scheduleUpdate() {
+        if (updateScheduled) return;
+        updateScheduled = true;
+        requestAnimationFrame(() => {
+          map.getSource('runs').setData({ type: 'FeatureCollection', features: currentFeatures });
+          updateScheduled = false;
+        });
+      }
 
       const finalize = () => {
         removeProgress(wrapper);
@@ -156,10 +166,13 @@
 
       es.addEventListener('feature', (e) => {
         currentFeatures.push(JSON.parse(e.data));
-        map.getSource('runs').setData({ type: 'FeatureCollection', features: currentFeatures });
+        scheduleUpdate();
       });
 
-      es.addEventListener('done', finalize);
+      es.addEventListener('done', () => {
+        scheduleUpdate();
+        finalize();
+      });
 
       es.onerror = finalize;
     }


### PR DESCRIPTION
## Summary
- stream individual features over the `stream_runs` SSE endpoint
- update front-end to draw lines as soon as they arrive

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68586bd69b6483219e1e51da405509dc