### PR TITLE
Add activity icons for sidebar

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -46,8 +46,10 @@ def _normalize_activity_type(raw_type):
         return 'run'
     if 'bike' in t or 'cycl' in t or 'ride' in t:
         return 'bike'
-    if 'walk' in t or 'hike' in t:
+    if 'walk' in t:
         return 'walk'
+    if 'hike' in t:
+        return 'hike'
     return 'other'
 
 

--- a/server/import_runs.py
+++ b/server/import_runs.py
@@ -22,8 +22,10 @@ def _normalize_activity_type(raw_type):
         return 'run'
     if 'bike' in t or 'cycl' in t or 'ride' in t:
         return 'bike'
-    if 'walk' in t or 'hike' in t:
+    if 'walk' in t:
         return 'walk'
+    if 'hike' in t:
+        return 'hike'
     return 'other'
 
 

--- a/server/mobile_template.html
+++ b/server/mobile_template.html
@@ -691,6 +691,12 @@
         const startDate = new Date(run.metadata.start_time);
         const distance = (run.metadata.distance * 0.000621371).toFixed(2);
         const duration = formatDuration(run.metadata.duration);
+        const type = run.metadata.activity_type || 'other';
+        let icon = '❓';
+        if (type === 'run') icon = '🏃';
+        else if (type === 'bike') icon = '🚴';
+        else if (type === 'walk') icon = '🚶';
+        else if (type === 'hike') icon = '🥾';
         
         card.innerHTML = `
           <div style="display: flex; align-items: center;">
@@ -702,6 +708,7 @@
                 <span>⏱️ ${duration}</span>
               </div>
             </div>
+            <div style="font-size:20px;margin-left:4px;">${icon}</div>
           </div>
         `;
 

--- a/web/index.html
+++ b/web/index.html
@@ -742,21 +742,29 @@
         const card = document.createElement('div');
         card.className = 'run-card';
         card.dataset.runId = run.id;
-        
+
         const startDate = new Date(run.metadata.start_time);
         const distance = (run.metadata.distance * 0.000621371).toFixed(2); // Convert to miles
         const duration = formatDuration(run.metadata.duration);
-        
+        const type = run.metadata.activity_type || 'other';
+        let icon = '❓';
+        if (type === 'run') icon = '🏃';
+        else if (type === 'bike') icon = '🚴';
+        else if (type === 'walk') icon = '🚶';
+        const extra = (type === 'other' && run.metadata.activity_raw) ? `<div style="font-size:11px;color:#666;">${run.metadata.activity_raw}</div>` : '';
+
         card.innerHTML = `
           <div style="display: flex; align-items: center;">
             <input type="checkbox" class="run-checkbox" checked>
-            <div style="flex: 1;">
+            <div style="flex: 1; margin-left:4px;">
               <div class="run-date">${startDate.toLocaleDateString()} ${startDate.toLocaleTimeString()}</div>
               <div class="run-stats">
                 <span>📏 ${distance} mi</span>
                 <span>⏱️ ${duration}</span>
               </div>
+              ${extra}
             </div>
+            <div style="font-size:20px;margin-left:4px;">${icon}</div>
           </div>
         `;
 

--- a/web/index.html
+++ b/web/index.html
@@ -751,6 +751,7 @@
         if (type === 'run') icon = '🏃';
         else if (type === 'bike') icon = '🚴';
         else if (type === 'walk') icon = '🚶';
+        else if (type === 'hike') icon = '🥾';
         const extra = (type === 'other' && run.metadata.activity_raw) ? `<div style="font-size:11px;color:#666;">${run.metadata.activity_raw}</div>` : '';
 
         card.innerHTML = `


### PR DESCRIPTION
## Summary
- parse activity type from GPX/TCX/FIT files
- store new `activity_type` and `activity_raw` metadata
- expose metadata in API and show icons in sidebar

## Testing
- `python -m py_compile server/app.py server/import_runs.py`


------
https://chatgpt.com/codex/tasks/task_e_68605249f6088321a0d704a708d0a54b