### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Run Heatmap
+# Activity Heatmap
 
-Visualize your entire running history on an interactive map.
+Visualize your entire GPS activity history on an interactive map.
 
 This project processes raw GPS files (Strava export, Garmin Connect, etc.) and serves them with a lightweight Flask application. MapLibre GL JS renders a slippy map using OpenStreetMap tiles.
 
@@ -11,8 +11,10 @@ This project processes raw GPS files (Strava export, Garmin Connect, etc.) and s
 - R-tree spatial index and on-the-fly clipping for responsive panning/zooming
 - Heatmap style polyline rendering on an OpenStreetMap basemap
 - **Server–sent events** for progressive GeoJSON streaming with progress bars
-- Draw a polygon to select an area and list all runs intersecting it
-- Sidebar with run metadata (date, distance, duration) and controls to show/hide runs
+- Draw a polygon to select an area and list all activities intersecting it
+- Sidebar with activity metadata (type, date, distance, duration) and controls to show/hide activities
+- Upload new **GPX** files directly from the browser
+- Optional script to build an offline Android app (see **MOBILE_SETUP.md**)
 
 ## Prerequisites
 
@@ -24,7 +26,7 @@ This project processes raw GPS files (Strava export, Garmin Connect, etc.) and s
   sudo apt install python3-venv libspatialindex-dev
   ```
 
-## Import your runs
+## Import your activities
 
 1. Put your raw GPS files under `data/raw/` (git ignored):
    - Strava exports: `.fit.gz`, `.gpx.gz`, `.fit`, `.gpx`
@@ -51,9 +53,9 @@ flask run
 Open [http://127.0.0.1:5000/](http://127.0.0.1:5000/) in your browser.  
 Pan/zoom to your area and watch the heatmap stream in.
 
-## Selecting runs
+## Selecting activities
 
-Use the **⊙** button to draw a lasso polygon. The sidebar lists each run in that area with distance and duration. You can toggle runs on/off or clear the selection to return to viewing everything.
+Use the **⊙** button to draw a lasso polygon. The sidebar lists each activity in that area with distance and duration. You can toggle activities on/off or clear the selection to return to viewing everything.
 
 ## Customizing style
 
@@ -77,6 +79,13 @@ Increase the opacity or adjust the width stops for a bolder heatmap.
 
 - Drop new GPS files into `data/raw/` and rerun `python import_runs.py`.
 - The server streams GeoJSON on demand—no tile generation step.
-- Runs are cached using `lru_cache` and responses include caching headers.
+- Activities are cached using `lru_cache` and responses include caching headers.
 
-Enjoy exploring your run history!
+## Mobile app
+
+Run `python build_mobile.py` inside the `server/` directory to generate an
+Android APK with your activities bundled for offline viewing. The script will verify
+prerequisites, build the assets and optionally package the app using Capacitor.
+See **MOBILE_SETUP.md** for a detailed guide.
+
+Enjoy exploring your activity history!


### PR DESCRIPTION
## Summary
- generalize instructions from runs to GPS activities
- still highlight GPX upload and the mobile app script

## Testing
- `python -m py_compile server/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68617d3b5c68832199a0cd5a6c65d7ac