### PR TITLE
Clarify Garmin export instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project processes raw GPS files (Strava export, Garmin Connect, etc.) and s
 1. Put your raw GPS files under `data/raw/` (git ignored):
    - Strava exports: `.fit.gz`, `.gpx.gz`, `.fit`, `.gpx`
    - Garmin Connect exports: `.zip` containing `.fit` or `.txt`/`.tcx`
-     - After extracting the main export, look under
+     - After requesting a Garmin export at https://www.garmin.com/en-US/account/datamanagement/exportdata/, look under
        `DI_CONNECT/DI-Connect-Fitness-Uploaded-Files/` for many
        `UploadedFiles*.zip` archives. Drop these zip files into
        `data/raw/` to import them.


### PR DESCRIPTION
## Summary
- clarify that Garmin exports contain multiple `UploadedFiles*.zip` archives under `DI_CONNECT/DI-Connect-Fitness-Uploaded-Files`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686180531b548321a6e84835d64410a6