### PR TITLE
Fix mobile PMTiles and persist uploads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Key features to understand:
 
 - **Lasso/Selection tool**: Users draw a polygon on the map. Activities intersecting the area are listed in a sidebar. Each run can be toggled on or off to filter what is shown. Clearing the selection hides the sidebar and shows all runs again.
 - **Upload capability**: Users may upload GPX files which are added to the dataset and shown on the map.
+- **Persist uploads**: Uploaded runs must be stored locally so they remain visible after restarting the server or mobile app.
 - **Offline/mobile app**: `build_mobile.py` packages the mobile version as an Android APK with runs bundled locally.
 
 Project structure overview:

--- a/MOBILE_SETUP.md
+++ b/MOBILE_SETUP.md
@@ -32,9 +32,11 @@ The entire process is now handled by one script.
 
 2.  **Run the build script:**
     ```bash
-    python build_mobile.py
+    python build_mobile.py [--quick]
     ```
    *(Run `python make_pmtiles.py` beforehand if you want vector tiles packaged.)*
+   
+   Use the `--quick` flag to skip data conversion when you only changed HTML or JavaScript. It reuses the existing `mobile/` directory to speed up the build.
 
 The script will then:
 1.  ✅ **Check Prerequisites**: Verify that all required tools and files are present.
@@ -44,6 +46,28 @@ The script will then:
 5.  ✅ **Build the APK**: Create the final `running-heatmap-*.apk` file.
 
 The final APK will be placed in the `mobile/` directory, ready to be installed on your device.
+
+## Testing in the Browser
+
+Before installing the APK you can quickly verify the mobile build in Chrome.
+
+1. **Run the build script** to generate the web bundle:
+   ```bash
+   python build_mobile.py [--quick]
+   ```
+   The output is placed in `../mobile/www/`.
+2. **Serve the files locally**:
+   ```bash
+   cd ../mobile/www
+   python3 -m http.server 8000
+   ```
+   This starts a static server at <http://localhost:8000>.
+3. **Open the app in Chrome** at `http://localhost:8000` and use DevTools to
+   debug JavaScript, inspect network requests and simulate mobile devices.
+
+Using a local server mirrors how the app loads files from the device. Keep your
+paths relative (e.g. `data/runs.json.gz`) so they work from both `http://` and
+`file://` locations.
 
 ## Installing the APK
 
@@ -73,7 +97,7 @@ When you add new runs using the PC version, you can update your mobile app by fo
 
 2.  **Re-run the mobile build script:**
     ```bash
-    python build_mobile.py
+    python build_mobile.py [--quick]
     ```
 The script will regenerate the data and build a new APK with your latest runs.
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Increase the opacity or adjust the width stops for a bolder heatmap.
 Run `python build_mobile.py` inside the `server/` directory to generate an
 Android APK with your activities bundled for offline viewing. The script will verify
 prerequisites, build the assets and optionally package the app using Capacitor.
+For a faster rebuild when only templates or JavaScript change, you can pass
+`--quick` to reuse the existing data and skip the conversion step.
 See **MOBILE_SETUP.md** for a detailed guide.
 
 Enjoy exploring your activity history!

--- a/server/build_mobile.py
+++ b/server/build_mobile.py
@@ -248,20 +248,10 @@ def build_mobile_data():
         json.dump(runs_data, f, separators=(',', ':'))
     print(f"   - Wrote runs data to {runs_file}")
 
-    runs_plain = os.path.join(mobile_dir, 'data', 'runs.json')
-    with open(runs_plain, 'w') as f:
-        json.dump(runs_data, f, separators=(',', ':'))
-    print(f"   - Wrote runs data to {runs_plain}")
-
     index_file = os.path.join(mobile_dir, 'data', 'spatial_index.json.gz')
     with gzip.open(index_file, 'wt') as f:
         json.dump(spatial_index, f, separators=(',', ':'))
     print(f"   - Wrote spatial index to {index_file}")
-
-    index_plain = os.path.join(mobile_dir, 'data', 'spatial_index.json')
-    with open(index_plain, 'w') as f:
-        json.dump(spatial_index, f, separators=(',', ':'))
-    print(f"   - Wrote spatial index to {index_plain}")
 
     pmtiles_src = 'runs.pmtiles'
     if os.path.exists(pmtiles_src):

--- a/server/build_mobile.py
+++ b/server/build_mobile.py
@@ -248,10 +248,20 @@ def build_mobile_data():
         json.dump(runs_data, f, separators=(',', ':'))
     print(f"   - Wrote runs data to {runs_file}")
 
+    runs_plain = os.path.join(mobile_dir, 'data', 'runs.json')
+    with open(runs_plain, 'w') as f:
+        json.dump(runs_data, f, separators=(',', ':'))
+    print(f"   - Wrote runs data to {runs_plain}")
+
     index_file = os.path.join(mobile_dir, 'data', 'spatial_index.json.gz')
     with gzip.open(index_file, 'wt') as f:
         json.dump(spatial_index, f, separators=(',', ':'))
     print(f"   - Wrote spatial index to {index_file}")
+
+    index_plain = os.path.join(mobile_dir, 'data', 'spatial_index.json')
+    with open(index_plain, 'w') as f:
+        json.dump(spatial_index, f, separators=(',', ':'))
+    print(f"   - Wrote spatial index to {index_plain}")
 
     pmtiles_src = 'runs.pmtiles'
     if os.path.exists(pmtiles_src):

--- a/server/mobile_template.html
+++ b/server/mobile_template.html
@@ -467,6 +467,17 @@
 
         try {
           await window.spatialIndex.loadData();
+          uploadedFeatures = window.spatialIndex.userRuns.map(run => ({
+            type: 'Feature',
+            geometry: run.geoms.full,
+            properties: { id: run.id }
+          }));
+          if (uploadedFeatures.length) {
+            map.getSource('uploadedRuns').setData({
+              type: 'FeatureCollection',
+              features: uploadedFeatures
+            });
+          }
           showStatus('Interactive data loaded');
           updateMapDisplay();
         } catch (error) {

--- a/web/index.html
+++ b/web/index.html
@@ -365,6 +365,18 @@
 
     const loadingIndicator = document.getElementById('loading-indicator');
     let uploadedFeatures = [];
+    const stored = localStorage.getItem('uploadedFeatures');
+    if (stored) {
+      try {
+        uploadedFeatures = JSON.parse(stored);
+        map.getSource('uploadedRuns').setData({
+          type: 'FeatureCollection',
+          features: uploadedFeatures
+        });
+      } catch (e) {
+        console.error('Failed to load stored uploads', e);
+      }
+    }
 
     // Map control button event listeners
     document.getElementById('zoom-in-btn').addEventListener('click', () => {
@@ -398,14 +410,15 @@
           alert('Upload failed: ' + txt);
         } else {
           const data = await resp.json();
-          if (data.features && data.features.length) {
-            uploadedFeatures = uploadedFeatures.concat(data.features);
-            map.getSource('uploadedRuns').setData({
-              type: 'FeatureCollection',
-              features: uploadedFeatures
-            });
-            updateMapDisplay();
-          }
+            if (data.features && data.features.length) {
+              uploadedFeatures = uploadedFeatures.concat(data.features);
+              map.getSource('uploadedRuns').setData({
+                type: 'FeatureCollection',
+                features: uploadedFeatures
+              });
+              localStorage.setItem('uploadedFeatures', JSON.stringify(uploadedFeatures));
+              updateMapDisplay();
+            }
         }
       } catch (err) {
         alert('Upload error: ' + err.message);


### PR DESCRIPTION
## Summary
- ensure uploaded runs persist across restarts
- include plain JSON in mobile builds to avoid WebView decompression issues
- restore user uploads on mobile app load
- persist uploaded runs in the web UI

## Testing
- `python -m py_compile server/build_mobile.py`
- `python -m flask --app app run --no-reload -p 5000` *(fails: No module named flask)*

------
https://chatgpt.com/codex/tasks/task_e_6865e566327083219813f606f4040b38