### PR TITLE
Improve mobile map loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Increase the opacity or adjust the width stops for a bolder heatmap.
 - Drop new GPS files into `data/raw/` and rerun `python import_runs.py`.
 - The server streams GeoJSON on demand—no tile generation step.
 - Activities are cached using `lru_cache` and responses include caching headers.
-- For even faster loading, run `python make_pmtiles.py` to generate `runs.pmtiles` (requires Tippecanoe).
+- For even faster loading, run `python make_pmtiles.py` to generate `runs.pmtiles` (requires Tippecanoe). The mobile and web apps automatically use this file and prefetch nearby map tiles for smoother panning.
 - A dataset of ~5k runs results in `runs.json.gz` around 2&nbsp;MB and cold-start under a second on recent phones.
 
 ## Mobile app

--- a/server/mobile_template.html
+++ b/server/mobile_template.html
@@ -425,7 +425,12 @@
         touchPitch: false
       });
 
+      // Prefetch surrounding tiles to avoid blank squares when panning
+      map.prefetchZoomDelta = 2;
+
       map.on('load', async () => {
+        const loader = document.getElementById('loading-indicator');
+        loader.style.display = 'block';
         // Add OSM tiles
         map.addSource('osm-tiles', {
           type: 'raster',
@@ -483,6 +488,8 @@
         } catch (error) {
           showStatus('Failed to load interactive data: ' + error.message);
           console.error('Data loading failed:', error);
+        } finally {
+          loader.style.display = 'none';
         }
       });
 

--- a/web/index.html
+++ b/web/index.html
@@ -299,6 +299,9 @@
       zoom: 4
     });
 
+    // Prefetch surrounding tiles for smoother panning
+    map.prefetchZoomDelta = 2;
+
     // Wait for PMTiles library to load
     function initializeMap() {
       map.addSource('osm-tiles', {


### PR DESCRIPTION
## Summary
- mention PMTiles/prefetching in README
- speed up map load by prefetching tiles and showing spinner while data loads
- enable tile prefetch on the web version as well

## Testing
- `pip install flask` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6866a24641e88321a32e37e4c2ea9a1b