### PR TITLE
Improve zoom transition performance

### DIFF
--- a/server/make_pmtiles.py
+++ b/server/make_pmtiles.py
@@ -58,7 +58,6 @@ def main():
         '-l', 'runs',
         '-Z', '5',          # Min zoom
         '-z', '16',         # Max zoom (higher for more detail)
-        '--tile-size=1024', # Larger tiles = fewer network requests
         '--buffer=16',      # Extra geometry around tile edges
         '--simplification=2',  # Aggressive simplification for speed
         '--no-tile-size-limit',

--- a/server/make_pmtiles.py
+++ b/server/make_pmtiles.py
@@ -58,10 +58,13 @@ def main():
         '-l', 'runs',
         '-Z', '5',          # Min zoom
         '-z', '16',         # Max zoom (higher for more detail)
+        '--tile-size=1024', # Larger tiles = fewer network requests
+        '--buffer=16',      # Extra geometry around tile edges
         '--simplification=2',  # Aggressive simplification for speed
         '--no-tile-size-limit',
         '--drop-densest-as-needed',  # Auto-drop features when too dense
         '--extend-zooms-if-still-dropping',  # Keep trying to fit data
+        '--simplify-only-low-zooms',  # Keep detail at high zooms
         '--progress-interval=1',  # Show progress every second
         'runs.geojson'
     ], check=True)

--- a/server/mobile_template.html
+++ b/server/mobile_template.html
@@ -425,8 +425,8 @@
         touchPitch: false
       });
 
-      // Prefetch surrounding tiles to avoid blank squares when panning
-      map.prefetchZoomDelta = 2;
+      // Aggressive tile prefetching for seamless zoom transitions
+      map.prefetchZoomDelta = 4;
 
       map.on('load', async () => {
         const loader = document.getElementById('loading-indicator');
@@ -465,8 +465,24 @@
         if (head.ok) {
           const protocol = new pmtiles.Protocol();
           maplibregl.addProtocol('pmtiles', protocol.tile.bind(protocol));
-          map.addSource('runsVec', {type:'vector', url:'pmtiles://data/runs.pmtiles'});
-          map.addLayer({id:'runsVec', source:'runsVec', 'source-layer':'runs', type:'line', paint:{'line-color':'rgba(255,0,0,0.5)','line-width':['interpolate',['linear'],['zoom'],0,1,14,3]}});
+          map.addSource('runsVec', {
+            type: 'vector',
+            url: 'pmtiles://data/runs.pmtiles',
+            buffer: 128,        // Extra pixels around each tile edge
+            maxzoom: 16,        // Match PMTiles max zoom for better caching
+            minzoom: 5          // Match PMTiles min zoom
+          });
+          map.addLayer({
+            id: 'runsVec',
+            source: 'runsVec',
+            'source-layer': 'runs',
+            type: 'line',
+            paint: {
+              'line-color': 'rgba(255,0,0,0.5)',
+              'line-width': ['interpolate', ['linear'], ['zoom'], 0, 1, 14, 3]
+            },
+            maxzoom: 24  // Allow overzoom for smooth transitions (higher than source maxzoom)
+          });
           pmtilesLoaded = true;
         }
 

--- a/web/index.html
+++ b/web/index.html
@@ -299,8 +299,8 @@
       zoom: 4
     });
 
-    // Prefetch surrounding tiles for smoother panning
-    map.prefetchZoomDelta = 2;
+    // Aggressive tile prefetching for seamless zoom transitions
+    map.prefetchZoomDelta = 4;
 
     // Wait for PMTiles library to load
     function initializeMap() {
@@ -322,7 +322,13 @@
 
       const protocol = new pmtiles.Protocol();
       maplibregl.addProtocol('pmtiles', protocol.tile);
-      map.addSource('runsVec', {type:'vector', url:'pmtiles://runs.pmtiles'});
+      map.addSource('runsVec', {
+        type: 'vector',
+        url: 'pmtiles://runs.pmtiles',
+        buffer: 128,        // Extra pixels around each tile edge
+        maxzoom: 16,        // Match PMTiles max zoom for better caching
+        minzoom: 5          // Match PMTiles min zoom
+      });
       map.addLayer({
         id:'runsVec',
         source:'runsVec',
@@ -331,7 +337,8 @@
         paint:{
           'line-color':'rgba(255,0,0,0.4)',
           'line-width':['interpolate',['linear'],['zoom'],5,0.5,10,1,14,2,16,3]
-        }
+        },
+        maxzoom: 24  // Allow overzoom for smooth transitions (higher than source maxzoom)
       });
 
       // Layer for newly uploaded runs


### PR DESCRIPTION
## Summary
- prefetch more tiles to reduce empty edges
- add buffer and zoom hints for PMTiles vector source
- allow overzoom on vector layer
- optimize PMTiles build flags
- keep web and mobile templates in sync

## Testing
- `python server/build_mobile.py --quick` *(fails: No module named 'shapely')*
- `python server/make_pmtiles.py` *(fails: No module named 'shapely')*

------
https://chatgpt.com/codex/tasks/task_e_6866b110dca0832183bda226bf39f4de