### PR TITLE
Fix service worker handling of PMTiles

### DIFF
--- a/server/sw_template.js
+++ b/server/sw_template.js
@@ -18,7 +18,9 @@ const STATIC_FILES = [
 
 // Data files to cache
 const DATA_FILES = [
-  './data/runs.pmtiles'
+  // PMTiles are loaded via range requests which are incompatible with
+  // service-worker precaching. Leave this array empty so the browser's
+  // normal fetch logic handles caching.
 ];
 
 // Install event - cache static files
@@ -71,6 +73,12 @@ self.addEventListener('activate', (event) => {
 
 // Fetch event - serve from cache when offline
 self.addEventListener('fetch', (event) => {
+  // Range requests (used by PMTiles) must bypass the cache entirely.
+  if (event.request.headers.has('range')) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
   const requestUrl = new URL(event.request.url);
   
   // Handle data files (PMTiles)


### PR DESCRIPTION
## Summary
- stop precaching PMTiles in the service worker
- bypass the cache for Range requests so PMTiles load correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686724a34f6083218fcd7624159550e8