### PR TITLE
Add basic test scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r server/requirements.txt pytest pytest-flask
+      - run: pytest -q
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm i -D @playwright/test
+      - run: npx playwright install --with-deps
+      - name: Launch Flask in background
+        run: |
+          python -m flask --app server.app run &
+          sleep 3
+      - run: npx playwright test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - run: npm i -D @playwright/test
+      - run: pip install -r server/requirements.txt
+      - name: Prepare test dataset
+        run: |
+          python - <<'EOF'
+          import pickle
+          from shapely.geometry import LineString
+          sample = {
+              1: {
+                  'bbox': (0, 0, 1, 1),
+                  'geoms': {
+                      'full': LineString([(0, 0), (1, 1)]),
+                      'high': LineString([(0, 0), (1, 1)]),
+                      'mid': LineString([(0, 0), (1, 1)]),
+                      'low': LineString([(0, 0), (1, 1)]),
+                      'coarse': LineString([(0, 0), (1, 1)])
+                  },
+                  'metadata': {}
+              }
+          }
+          with open('runs.pkl', 'wb') as f:
+              pickle.dump(sample, f)
+          open('runs.pmtiles', 'wb').close()
+          EOF
       - run: npx playwright install --with-deps
       - name: Launch Flask in background
         run: |

--- a/README.md
+++ b/README.md
@@ -103,4 +103,15 @@ adb install -r $(wslpath -w "$APK")
 ```
 See **MOBILE_SETUP.md** for a detailed guide on setting up the Windows `adb` server and debugging with Chrome DevTools.
 
+## Testing
+
+Basic unit and browser tests are included. Install the dev requirements then run:
+
+```bash
+pytest            # Python unit tests
+npx playwright test  # end-to-end tests
+```
+
+The GitHub Actions workflow runs these automatically on every push and pull request.
+
 Enjoy exploring your activity history!

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   "dependencies": {
     "rbush": "^3.0.0",
     "pmtiles": "^3.2.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.42.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  use: {
+    baseURL: 'http://127.0.0.1:5000',
+    headless: true,
+    viewport: { width: 1280, height: 800 },
+  },
+});

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-flask

--- a/server/app.py
+++ b/server/app.py
@@ -13,9 +13,15 @@ import os
 import subprocess
 
 
-# Load runs and build spatial index
-with open('runs.pkl', 'rb') as f:
-    runs = pickle.load(f)
+# path to the serialized dataset
+RUNS_PKL_PATH = os.environ.get("RUNS_PKL_PATH", "runs.pkl")
+
+# Load runs and build spatial index if file exists
+if os.path.exists(RUNS_PKL_PATH):
+    with open(RUNS_PKL_PATH, "rb") as f:
+        runs = pickle.load(f)
+else:
+    runs = {}
 
 idx = index.Index()
 for rid, run in runs.items():
@@ -125,7 +131,7 @@ def add_run(coords, metadata, source_name='upload'):
         },
     }
     idx.insert(rid, runs[rid]['bbox'])
-    with open('runs.pkl', 'wb') as f:
+    with open(RUNS_PKL_PATH, 'wb') as f:
         pickle.dump(runs, f)
     return rid
 
@@ -242,7 +248,7 @@ def update_runs():
         data = request.get_json()
         new_runs = data['runs']
 
-        pkl_path = 'runs.pkl'
+        pkl_path = RUNS_PKL_PATH
         if os.path.exists(pkl_path):
             with open(pkl_path, 'rb') as f:
                 existing = pickle.load(f)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+import pickle
+import tempfile
+import contextlib
+import pytest
+from server.app import app as flask_app
+
+# creates a temp CWD with a minimal runs.pkl and yields
+@pytest.fixture(scope="session", autouse=True)
+def temp_dataset(tmp_path_factory, monkeypatch):
+    tmpdir = tmp_path_factory.mktemp("rheat")
+    pkl = tmpdir / "runs.pkl"
+    sample = {1: {"bbox": (-1, -1, 1, 1), "geoms": {}, "metadata": {}}}
+    pkl.write_bytes(pickle.dumps(sample))
+    monkeypatch.chdir(tmpdir)
+    yield
+
+@pytest.fixture
+def client():
+    flask_app.config["TESTING"] = True
+    with flask_app.test_client() as c:
+        yield c

--- a/tests/e2e/heatmap.spec.ts
+++ b/tests/e2e/heatmap.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('PMTiles loads and lasso UI appears', async ({ page }) => {
+  await page.waitForResponse(r =>
+    r.url().includes('runs.pmtiles') && r.status() === 206);
+
+  const center = { x: 400, y: 400 };
+  await page.mouse.move(center.x, center.y);
+  await page.mouse.down();
+  await page.mouse.move(center.x + 50, center.y);
+  await page.mouse.move(center.x + 50, center.y + 50);
+  await page.mouse.move(center.x, center.y + 50);
+  await page.mouse.up();
+
+  await expect(page.locator('#side-panel')).toHaveClass(/open/);
+  await expect(page.locator('#panel-content .run-card')).toHaveCountGreaterThan(0);
+});

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,22 @@
+import io
+import textwrap
+import json
+
+def tiny_gpx():
+    return textwrap.dedent("""\
+        <gpx><trk><trkseg>
+          <trkpt lat="0.0" lon="0.0"/><trkpt lat="0.01" lon="0.01"/>
+        </trkseg></trk></gpx>""").encode()
+
+def test_upload_and_lasso_roundtrip(client):
+    # upload
+    data = {"files": (io.BytesIO(tiny_gpx()), "f.gpx")}
+    r = client.post("/api/upload", data=data, content_type="multipart/form-data")
+    assert r.status_code == 200
+    new_id = r.get_json()["added"][0]
+
+    # lasso polygon around the two pts
+    poly = [[-0.1,-0.1],[0.1,-0.1],[0.1,0.1],[-0.1,0.1],[-0.1,-0.1]]
+    r = client.post("/api/runs_in_area", json={"polygon": poly})
+    ids = [f["id"] for f in r.get_json()["runs"]]
+    assert new_id in ids


### PR DESCRIPTION
## Summary
- add pytest and playwright scaffolding
- configure GitHub Actions CI for unit and e2e tests
- document test commands in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npx playwright test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68699012510c83219ec5a76435e1aedd