### PR TITLE
Fix tests and dataset handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - run: npm i -D @playwright/test
+      - run: pip install -r server/requirements.txt
+      - name: Prepare test dataset
+        run: |
+          python - <<'EOF'
+          import pickle
+          from shapely.geometry import LineString
+          sample = {
+              1: {
+                  'bbox': (0, 0, 1, 1),
+                  'geoms': {
+                      'full': LineString([(0, 0), (1, 1)]),
+                      'high': LineString([(0, 0), (1, 1)]),
+                      'mid': LineString([(0, 0), (1, 1)]),
+                      'low': LineString([(0, 0), (1, 1)]),
+                      'coarse': LineString([(0, 0), (1, 1)])
+                  },
+                  'metadata': {}
+              }
+          }
+          with open('runs.pkl', 'wb') as f:
+              pickle.dump(sample, f)
+          open('runs.pmtiles', 'wb').close()
+          EOF
       - run: npx playwright install --with-deps
       - name: Launch Flask in background
         run: |

--- a/server/app.py
+++ b/server/app.py
@@ -13,9 +13,15 @@ import os
 import subprocess
 
 
-# Load runs and build spatial index
-with open('runs.pkl', 'rb') as f:
-    runs = pickle.load(f)
+# path to the serialized dataset
+RUNS_PKL_PATH = os.environ.get("RUNS_PKL_PATH", "runs.pkl")
+
+# Load runs and build spatial index if file exists
+if os.path.exists(RUNS_PKL_PATH):
+    with open(RUNS_PKL_PATH, "rb") as f:
+        runs = pickle.load(f)
+else:
+    runs = {}
 
 idx = index.Index()
 for rid, run in runs.items():
@@ -125,7 +131,7 @@ def add_run(coords, metadata, source_name='upload'):
         },
     }
     idx.insert(rid, runs[rid]['bbox'])
-    with open('runs.pkl', 'wb') as f:
+    with open(RUNS_PKL_PATH, 'wb') as f:
         pickle.dump(runs, f)
     return rid
 
@@ -242,7 +248,7 @@ def update_runs():
         data = request.get_json()
         new_runs = data['runs']
 
-        pkl_path = 'runs.pkl'
+        pkl_path = RUNS_PKL_PATH
         if os.path.exists(pkl_path):
             with open(pkl_path, 'rb') as f:
                 existing = pickle.load(f)


### PR DESCRIPTION
## Summary
- make dataset path configurable and ignore missing runs.pkl
- update tests to reconfigure app for a temporary dataset
- install server requirements in e2e workflow
- prepare minimal dataset before running browser tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_6869924041248321970000ae849d4491