### PR TITLE
Fix tests scaffolding for CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,19 +8,25 @@ from rtree import index
 
 # creates a temp CWD with a minimal runs.pkl and yields
 @pytest.fixture(scope="session", autouse=True)
-def temp_dataset(tmp_path_factory, monkeypatch):
+def temp_dataset(tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("rheat")
     pkl = tmpdir / "runs.pkl"
     sample = {1: {"bbox": (-1, -1, 1, 1), "geoms": {}, "metadata": {}}}
     pkl.write_bytes(pickle.dumps(sample))
-    monkeypatch.chdir(tmpdir)
+
+    orig = os.getcwd()
+    os.chdir(tmpdir)
+
     # reconfigure the app to use this temporary dataset
     flask_app.RUNS_PKL_PATH = str(pkl)
     flask_app.runs = sample
     flask_app.idx = index.Index()
     for rid, run in sample.items():
         flask_app.idx.insert(rid, run["bbox"])
+
     yield
+
+    os.chdir(orig)
 
 @pytest.fixture
 def client():

--- a/tests/e2e/heatmap.spec.ts
+++ b/tests/e2e/heatmap.spec.ts
@@ -6,7 +6,7 @@ test.beforeEach(async ({ page }) => {
 
 test('PMTiles loads and lasso UI appears', async ({ page }) => {
   await page.waitForResponse(r =>
-    r.url().includes('runs.pmtiles') && r.status() === 206);
+    r.url().includes('runs.pmtiles') && (r.status() === 200 || r.status() === 206));
 
   const center = { x: 400, y: 400 };
   await page.mouse.move(center.x, center.y);


### PR DESCRIPTION
## Summary
- fix session-scoped dataset fixture
- relax expected HTTP status in Playwright test

## Testing
- `pytest -q tests/unit/test_api.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npx playwright test` *(fails to install playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6869964c13408321a3373310e1fd3f1d