### PR TITLE
Fix Playwright test timing issues

### DIFF
--- a/tests/e2e/heatmap.spec.ts
+++ b/tests/e2e/heatmap.spec.ts
@@ -1,12 +1,19 @@
 import { test, expect } from "@playwright/test";
 
-test.beforeEach(async ({ page }) => {
-  await page.goto('/');
-});
-
 test('PMTiles loads and lasso UI appears', async ({ page }) => {
-  await page.waitForResponse(r =>
-    r.url().includes('runs.pmtiles') && (r.status() === 200 || r.status() === 206));
+  await Promise.all([
+    page.waitForResponse(r =>
+      r.url().includes('runs.pmtiles') && (r.status() === 200 || r.status() === 206)),
+    page.goto('/')
+  ]);
+
+  // Focus map on the temporary dataset location
+  await page.evaluate(() => {
+    // @ts-ignore
+    map.setCenter([0.5, 0.5]);
+    // @ts-ignore
+    map.setZoom(12);
+  });
 
   const center = { x: 400, y: 400 };
   await page.mouse.move(center.x, center.y);


### PR DESCRIPTION
## Summary
- avoid missing PMTiles request by waiting for it while navigating
- focus the map on the sample dataset before drawing the lasso

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686998054a5c832186049771a434fd31