### PR TITLE
Improve mobile map stability

### DIFF
--- a/server/mobile_template.html
+++ b/server/mobile_template.html
@@ -478,8 +478,12 @@
         console.log('Map error details:', e);
       });
 
-      // Aggressive tile prefetching for seamless zoom transitions
-      map.prefetchZoomDelta = 4;
+      // Moderate prefetching to limit memory growth
+      map.prefetchZoomDelta = 3;
+      // Cap tile cache to avoid long-term memory buildup
+      if (map.setMaxTileCacheSize) {
+        map.setMaxTileCacheSize(512);
+      }
 
       map.on('load', async () => {
         const loader = document.getElementById('loading-indicator');

--- a/web/index.html
+++ b/web/index.html
@@ -325,8 +325,12 @@
       console.log('Map error details:', e);
     });
 
-    // Aggressive tile prefetching for seamless zoom transitions
-    map.prefetchZoomDelta = 4;
+    // Moderate prefetching to reduce memory usage on mobile
+    map.prefetchZoomDelta = 3;
+    // Limit how many tiles are retained to avoid crashes after long panning
+    if (map.setMaxTileCacheSize) {
+      map.setMaxTileCacheSize(512);
+    }
 
     // Wait for PMTiles library to load
     function initializeMap() {


### PR DESCRIPTION
## Summary
- cap tile cache size for mobile and web maps
- reduce tile prefetching to avoid memory growth

## Testing
- `flask run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a5933b848321a314fe7e30ae7a4a