### PR TITLE
Add extras sidebar with last activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project processes raw GPS files (Strava export, Garmin Connect, etc.) and s
 - Draw a polygon to select an area and list the intersecting activities
 - Sidebar shows metadata (type, date, distance, duration) and lets you toggle individual runs
 - Upload new **GPX** files right in the browser—they are stored locally and persist between sessions
+- Extras panel with last uploaded activity and more tools
 - `build_mobile.py` packages an offline Android app (see **MOBILE_SETUP.md**)
 
 ## Prerequisites

--- a/server/AndroidManifest.xml.template
+++ b/server/AndroidManifest.xml.template
@@ -40,4 +40,6 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 </manifest>

--- a/server/app.py
+++ b/server/app.py
@@ -235,6 +235,27 @@ def upload_gpx():
     return jsonify({'added': added, 'features': features})
 
 
+@app.route('/api/last_activity')
+def last_activity():
+    if not runs:
+        return jsonify({})
+    latest_id = None
+    latest_time = None
+    for rid, run in runs.items():
+        t = run['metadata'].get('start_time')
+        if t and (latest_time is None or t > latest_time):
+            latest_time = t
+            latest_id = rid
+    if latest_id is None:
+        return jsonify({})
+    meta = runs[latest_id]['metadata'].copy()
+    if meta.get('start_time') and hasattr(meta['start_time'], 'isoformat'):
+        meta['start_time'] = meta['start_time'].isoformat()
+    if meta.get('end_time') and hasattr(meta['end_time'], 'isoformat'):
+        meta['end_time'] = meta['end_time'].isoformat()
+    return jsonify({'id': latest_id, 'metadata': meta})
+
+
 @app.route('/update_runs', methods=['POST'])
 def update_runs():
     global runs, idx

--- a/server/mobile_template.html
+++ b/server/mobile_template.html
@@ -1173,6 +1173,8 @@
           return;
         }
         
+        console.log('[HEATMAP-DEBUG] Latest activity found - ID:', latestRun.id, 'Date:', latestRun.metadata.start_time, 'Source:', latestRun.metadata.source_file || 'PMTiles');
+        
         const card = document.createElement('div');
         card.className = 'run-card';
         card.dataset.runId = latestRun.id;
@@ -1201,11 +1203,13 @@
         checkbox.addEventListener('change', (e) => {
           if (e.target.checked) {
             // Show only this run
+            console.log('[HEATMAP-DEBUG] Filtering to show only run with ID:', latestRun.id);
             selectedRuns.clear();
             selectedRuns.add(String(latestRun.id));
             sidebarOpen = true; // Enable filtering
           } else {
             // Show all runs
+            console.log('[HEATMAP-DEBUG] Clearing filters to show all runs');
             selectedRuns.clear();
             sidebarOpen = false; // Disable filtering
           }
@@ -1213,8 +1217,77 @@
         });
         
         container.appendChild(card);
+        
+        // Add clear user uploads card
+        if (window.spatialIndex && window.spatialIndex.userRuns && window.spatialIndex.userRuns.length > 0) {
+          const clearCard = document.createElement('div');
+          clearCard.className = 'run-card';
+          clearCard.style.marginTop = '16px';
+          clearCard.style.borderColor = '#dc3545';
+          clearCard.innerHTML = `
+            <div style="text-align:center;padding:8px;">
+              <div style="font-weight:bold;margin-bottom:8px;">User Uploads</div>
+              <div style="font-size:12px;color:#666;margin-bottom:12px;">${window.spatialIndex.userRuns.length} uploaded activities</div>
+              <button id="clear-uploads-btn" style="
+                background:#dc3545;
+                color:white;
+                border:none;
+                padding:8px 16px;
+                border-radius:4px;
+                cursor:pointer;
+                font-size:14px;
+                width:100%;
+              ">Clear All Uploads</button>
+            </div>`;
+          
+          const clearBtn = clearCard.querySelector('#clear-uploads-btn');
+          clearBtn.addEventListener('click', () => {
+            if (confirm('Are you sure you want to clear all uploaded activities? This cannot be undone.')) {
+              clearUserUploads();
+            }
+          });
+          
+          container.appendChild(clearCard);
+        }
+        
       } catch (e) {
         console.error('Failed to fetch last activity', e);
+      }
+    }
+    
+    function clearUserUploads() {
+      try {
+        // Clear localStorage
+        localStorage.removeItem('userRuns');
+        
+        // Clear spatialIndex
+        if (window.spatialIndex) {
+          window.spatialIndex.userRuns = [];
+          window.spatialIndex.spatialIndex = window.spatialIndex.spatialIndex.filter(item => 
+            !window.spatialIndex.userRuns.some(run => run.id === item.id)
+          );
+          window.spatialIndex.nextId = 1;
+        }
+        
+        // Clear any filtering
+        selectedRuns.clear();
+        sidebarOpen = false;
+        
+        // Update map display
+        updateMapDisplay();
+        
+        // Close and reopen extras panel to refresh
+        const panel = document.getElementById('extras-panel');
+        panel.classList.remove('open');
+        setTimeout(() => {
+          panel.classList.add('open');
+          fetchLastActivity();
+        }, 100);
+        
+        console.log('[HEATMAP-DEBUG] Cleared all user uploads');
+        
+      } catch (e) {
+        console.error('Failed to clear user uploads', e);
       }
     }
 
@@ -1243,8 +1316,13 @@
             
             if (geom && geom.coordinates && geom.coordinates.length > 1) {
               // Apply sidebar filtering if active
-              if (sidebarOpen && selectedRuns.size > 0 && !selectedRuns.has(run.id)) {
+              if (sidebarOpen && selectedRuns.size > 0 && !selectedRuns.has(String(run.id))) {
+                console.log('[HEATMAP-DEBUG] Filtering out user run ID:', run.id, 'SelectedRuns:', Array.from(selectedRuns));
                 return; // Skip this run if it's not selected
+              }
+              
+              if (sidebarOpen && selectedRuns.size > 0) {
+                console.log('[HEATMAP-DEBUG] Including user run ID:', run.id, 'in filtered display');
               }
               
               allRunFeatures.push({
@@ -1298,6 +1376,9 @@
           if (sidebarOpen && selectedRuns.size > 0) {
             const ids = Array.from(selectedRuns, id => Number(id));
             filter = ['in', ['get', 'id'], ['literal', ids]];
+            console.log('[HEATMAP-DEBUG] Applying PMTiles filter for IDs:', ids);
+          } else {
+            console.log('[HEATMAP-DEBUG] Clearing PMTiles filter - showing all PMTiles runs');
           }
           map.setFilter('runsVec', filter);
         }

--- a/server/mobile_template.html
+++ b/server/mobile_template.html
@@ -1084,21 +1084,57 @@
 
     async function fetchLastActivity() {
       try {
-        const resp = await fetch('/api/last_activity');
-        if (!resp.ok) return;
-        const data = await resp.json();
         const container = document.getElementById('extras-content');
         container.innerHTML = '';
-        if (!data || !data.id) {
+        
+        let allRuns = [];
+        
+        // Get PMTiles runs (pre-packaged data) - query with large bbox to get all runs
+        try {
+          const worldBbox = [-180, -90, 180, 90]; // World coordinates
+          const pmtilesRuns = await window.spatialIndex.queryPMTilesInPolygon([
+            [-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]
+          ]);
+          allRuns.push(...pmtilesRuns);
+        } catch (error) {
+          console.warn('Failed to query PMTiles runs:', error);
+        }
+        
+        // Get user uploaded runs
+        if (window.spatialIndex && window.spatialIndex.userRuns) {
+          allRuns.push(...window.spatialIndex.userRuns);
+        }
+        
+        if (allRuns.length === 0) {
           container.textContent = 'No activities';
           return;
         }
+        
+        // Find the most recent run by start_time from all sources
+        let latestRun = null;
+        let latestTime = null;
+        
+        for (const run of allRuns) {
+          if (run.metadata && run.metadata.start_time) {
+            const startTime = new Date(run.metadata.start_time);
+            if (!latestTime || startTime > latestTime) {
+              latestTime = startTime;
+              latestRun = run;
+            }
+          }
+        }
+        
+        if (!latestRun) {
+          container.textContent = 'No activities';
+          return;
+        }
+        
         const card = document.createElement('div');
         card.className = 'run-card';
-        const startDate = new Date(data.metadata.start_time);
-        const distance = (data.metadata.distance * 0.000621371).toFixed(2);
-        const duration = formatDuration(data.metadata.duration);
-        const type = data.metadata.activity_type || 'other';
+        const startDate = new Date(latestRun.metadata.start_time);
+        const distance = (latestRun.metadata.distance * 0.000621371).toFixed(2);
+        const duration = formatDuration(latestRun.metadata.duration);
+        const type = latestRun.metadata.activity_type || 'other';
         let icon = '❓';
         if (type === 'run') icon = '🏃';
         else if (type === 'bike' || type === 'biking') icon = '🚴';

--- a/server/mobile_template.html
+++ b/server/mobile_template.html
@@ -1250,6 +1250,34 @@
           container.appendChild(clearCard);
         }
         
+        // Add current location card
+        const locationCard = document.createElement('div');
+        locationCard.className = 'run-card';
+        locationCard.style.marginTop = '16px';
+        locationCard.style.borderColor = '#007bff';
+        locationCard.innerHTML = `
+          <div style="text-align:center;padding:8px;">
+            <div style="font-weight:bold;margin-bottom:8px;">📍 Current Location</div>
+            <div style="font-size:12px;color:#666;margin-bottom:12px;">Zoom to your current position</div>
+            <button id="location-btn" style="
+              background:#007bff;
+              color:white;
+              border:none;
+              padding:8px 16px;
+              border-radius:4px;
+              cursor:pointer;
+              font-size:14px;
+              width:100%;
+            ">Find My Location</button>
+          </div>`;
+        
+        const locationBtn = locationCard.querySelector('#location-btn');
+        locationBtn.addEventListener('click', () => {
+          zoomToCurrentLocation();
+        });
+        
+        container.appendChild(locationCard);
+        
       } catch (e) {
         console.error('Failed to fetch last activity', e);
       }
@@ -1288,6 +1316,98 @@
         
       } catch (e) {
         console.error('Failed to clear user uploads', e);
+      }
+    }
+    
+    async function zoomToCurrentLocation() {
+      const locationBtn = document.getElementById('location-btn');
+      
+      // Update button to show loading state
+      const originalText = locationBtn.textContent;
+      locationBtn.textContent = 'Getting location...';
+      locationBtn.disabled = true;
+      
+      try {
+        // Import Capacitor Geolocation
+        const { Geolocation } = Capacitor;
+        
+        // Request permissions first
+        const permissions = await Geolocation.requestPermissions();
+        console.log('[HEATMAP-DEBUG] Location permissions:', permissions);
+        
+        if (permissions.location !== 'granted') {
+          throw new Error('Location permission denied');
+        }
+        
+        // Get current position using Capacitor API
+        const position = await Geolocation.getCurrentPosition({
+          enableHighAccuracy: true,
+          timeout: 10000
+        });
+        
+        const { latitude, longitude } = position.coords;
+        console.log('[HEATMAP-DEBUG] Current location:', latitude, longitude);
+        
+        // Remove existing location marker if it exists
+        if (map.getSource('current-location')) {
+          if (map.getLayer('current-location-marker')) {
+            map.removeLayer('current-location-marker');
+          }
+          map.removeSource('current-location');
+        }
+        
+        // Add current location marker
+        map.addSource('current-location', {
+          type: 'geojson',
+          data: {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [longitude, latitude]
+            }
+          }
+        });
+        
+        map.addLayer({
+          id: 'current-location-marker',
+          type: 'circle',
+          source: 'current-location',
+          paint: {
+            'circle-radius': 8,
+            'circle-color': '#007bff',
+            'circle-stroke-width': 3,
+            'circle-stroke-color': '#ffffff'
+          }
+        });
+        
+        // Zoom to location
+        map.flyTo({
+          center: [longitude, latitude],
+          zoom: 15,
+          duration: 2000
+        });
+        
+        // Restore button
+        locationBtn.textContent = originalText;
+        locationBtn.disabled = false;
+        
+      } catch (error) {
+        console.error('[HEATMAP-DEBUG] Geolocation error:', error);
+        
+        let errorMessage = 'Unable to get your location';
+        if (error.message.includes('denied') || error.message.includes('permission')) {
+          errorMessage = 'Location access denied. Please enable location permissions in your device settings.';
+        } else if (error.message.includes('unavailable')) {
+          errorMessage = 'Location information unavailable. Make sure GPS is enabled.';
+        } else if (error.message.includes('timeout')) {
+          errorMessage = 'Location request timed out. Please try again.';
+        }
+        
+        alert(errorMessage);
+        
+        // Restore button
+        locationBtn.textContent = originalText;
+        locationBtn.disabled = false;
       }
     }
 

--- a/server/mobile_template.html
+++ b/server/mobile_template.html
@@ -291,6 +291,35 @@
       background: #e3f2fd;
     }
 
+    /* Extras panel */
+    #extras-panel {
+      position: absolute;
+      top: env(safe-area-inset-top, 0px);
+      left: -100vw;
+      width: 85vw;
+      max-width: 360px;
+      height: calc(100vh - env(safe-area-inset-top, 0px));
+      background: white;
+      box-shadow: 2px 0 10px rgba(0,0,0,0.15);
+      transition: left 0.3s ease;
+      z-index: 1000;
+      overflow-y: auto;
+    }
+
+    #extras-panel.open {
+      left: 0;
+    }
+
+    .extras-header {
+      padding: 18px;
+      background: #f8f9fa;
+      border-bottom: 1px solid #dee2e6;
+      font-weight: bold;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
     /* Mobile-specific overlay for drawing */
     #drawing-overlay {
       position: absolute;
@@ -361,6 +390,7 @@
     <div class="control-btn" id="lasso-btn" title="Select Area">⊙</div>
     <div class="control-btn" id="clear-selection-btn" title="Clear Selection" style="display: none;">✕</div>
     <div class="control-btn" id="upload-btn" title="Upload GPX">⤴</div>
+    <div class="control-btn" id="extras-btn" title="More">⋯</div>
     <input type="file" id="file-input" accept=".gpx" multiple style="display:none;" />
   </div>
   
@@ -385,6 +415,11 @@
     <div class="panel-summary" id="panel-summary">
       <!-- Summary info will be shown here -->
     </div>
+  </div>
+
+  <div id="extras-panel">
+    <div class="extras-header">Extra Features<span id="extras-close" style="cursor:pointer">×</span></div>
+    <div id="extras-content" class="panel-content"></div>
   </div>
 
   <div id="progress-container"></div>
@@ -1047,6 +1082,38 @@
       }
     }
 
+    async function fetchLastActivity() {
+      try {
+        const resp = await fetch('/api/last_activity');
+        if (!resp.ok) return;
+        const data = await resp.json();
+        const container = document.getElementById('extras-content');
+        container.innerHTML = '';
+        if (!data || !data.id) {
+          container.textContent = 'No activities';
+          return;
+        }
+        const card = document.createElement('div');
+        card.className = 'run-card';
+        const startDate = new Date(data.metadata.start_time);
+        const distance = (data.metadata.distance * 0.000621371).toFixed(2);
+        const duration = formatDuration(data.metadata.duration);
+        const type = data.metadata.activity_type || 'other';
+        let icon = '❓';
+        if (type === 'run') icon = '🏃';
+        else if (type === 'bike' || type === 'biking') icon = '🚴';
+        else if (type === 'walk') icon = '🚶';
+        else if (type === 'hike') icon = '🥾';
+        card.innerHTML = `
+          <div class="run-date">${startDate.toLocaleDateString()} ${startDate.toLocaleTimeString()}</div>
+          <div class="run-stats"><span>📏 ${distance} mi</span><span>⏱️ ${duration}</span></div>
+          <div style="font-size:20px;margin-top:4px;">${icon}</div>`;
+        container.appendChild(card);
+      } catch (e) {
+        console.error('Failed to fetch last activity', e);
+      }
+    }
+
       function updateMapDisplay() {
         // Rebuild the unified runs layer to include both PMTiles and local runs
         updateUnifiedRunsLayer();
@@ -1336,6 +1403,20 @@
 
       document.getElementById('upload-btn').addEventListener('click', () => {
         document.getElementById('file-input').click();
+      });
+
+      document.getElementById('extras-btn').addEventListener('click', () => {
+        const panel = document.getElementById('extras-panel');
+        if (panel.classList.contains('open')) {
+          panel.classList.remove('open');
+        } else {
+          panel.classList.add('open');
+          fetchLastActivity();
+        }
+      });
+
+      document.getElementById('extras-close').addEventListener('click', () => {
+        document.getElementById('extras-panel').classList.remove('open');
       });
 
       document.getElementById('file-input').addEventListener('change', (e) => {

--- a/server/mobile_template.html
+++ b/server/mobile_template.html
@@ -310,6 +310,43 @@
       left: 0;
     }
 
+    #extras-panel.open.collapsed {
+      width: 60px;
+    }
+
+    #extras-panel.collapsed .extras-header,
+    #extras-panel.collapsed .panel-content {
+      display: none;
+    }
+
+    #extras-panel.collapsed .extras-expand-btn {
+      display: flex;
+    }
+
+    #extras-panel:not(.collapsed) .extras-expand-btn {
+      display: none;
+    }
+
+    /* Mobile expand button for collapsed extras panel */
+    .extras-expand-btn {
+      display: none;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: #007bff;
+      color: white;
+      border: none;
+      border-radius: 50%;
+      width: 40px;
+      height: 40px;
+      cursor: pointer;
+      align-items: center;
+      justify-content: center;
+      font-size: 20px;
+      z-index: 1001;
+    }
+
     .extras-header {
       padding: 18px;
       background: #f8f9fa;
@@ -418,7 +455,14 @@
   </div>
 
   <div id="extras-panel">
-    <div class="extras-header">Extra Features<span id="extras-close" style="cursor:pointer">×</span></div>
+    <div class="extras-expand-btn" id="extras-expand-btn">◄</div>
+    <div class="extras-header">
+      <span>Extra Features</span>
+      <div>
+        <span class="panel-collapse" id="extras-collapse">►</span>
+        <span id="extras-close" style="cursor:pointer">×</span>
+      </div>
+    </div>
     <div id="extras-content" class="panel-content"></div>
   </div>
 
@@ -1131,6 +1175,7 @@
         
         const card = document.createElement('div');
         card.className = 'run-card';
+        card.dataset.runId = latestRun.id;
         const startDate = new Date(latestRun.metadata.start_time);
         const distance = (latestRun.metadata.distance * 0.000621371).toFixed(2);
         const duration = formatDuration(latestRun.metadata.duration);
@@ -1143,7 +1188,30 @@
         card.innerHTML = `
           <div class="run-date">${startDate.toLocaleDateString()} ${startDate.toLocaleTimeString()}</div>
           <div class="run-stats"><span>📏 ${distance} mi</span><span>⏱️ ${duration}</span></div>
-          <div style="font-size:20px;margin-top:4px;">${icon}</div>`;
+          <div style="font-size:20px;margin-top:4px;">${icon}</div>
+          <div style="margin-top:8px;">
+            <label style="display:flex;align-items:center;font-size:12px;cursor:pointer;">
+              <input type="checkbox" class="last-activity-checkbox" style="margin-right:6px;">
+              Show only this activity
+            </label>
+          </div>`;
+        
+        // Add checkbox event listener
+        const checkbox = card.querySelector('.last-activity-checkbox');
+        checkbox.addEventListener('change', (e) => {
+          if (e.target.checked) {
+            // Show only this run
+            selectedRuns.clear();
+            selectedRuns.add(String(latestRun.id));
+            sidebarOpen = true; // Enable filtering
+          } else {
+            // Show all runs
+            selectedRuns.clear();
+            sidebarOpen = false; // Disable filtering
+          }
+          updateMapDisplay();
+        });
+        
         container.appendChild(card);
       } catch (e) {
         console.error('Failed to fetch last activity', e);
@@ -1453,6 +1521,22 @@
 
       document.getElementById('extras-close').addEventListener('click', () => {
         document.getElementById('extras-panel').classList.remove('open');
+        // Reset filtering to show all activities when closing the panel
+        selectedRuns.clear();
+        sidebarOpen = false;
+        updateMapDisplay();
+      });
+
+      // Extras panel collapse functionality
+      document.getElementById('extras-collapse').addEventListener('click', () => {
+        const panel = document.getElementById('extras-panel');
+        panel.classList.add('collapsed');
+      });
+
+      // Extras panel expand functionality
+      document.getElementById('extras-expand-btn').addEventListener('click', () => {
+        const panel = document.getElementById('extras-panel');
+        panel.classList.remove('collapsed');
       });
 
       document.getElementById('file-input').addEventListener('change', (e) => {

--- a/web/index.html
+++ b/web/index.html
@@ -259,6 +259,37 @@
     .control-link:hover {
       color: #0056b3;
     }
+
+    /* Extras panel */
+    #extras-panel {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 260px;
+      height: 100%;
+      background: white;
+      box-shadow: 2px 0 10px rgba(0,0,0,0.1);
+      transform: translateX(-100%);
+      transition: transform 0.3s ease;
+      z-index: 1000;
+      display: none;
+      overflow-y: auto;
+    }
+
+    #extras-panel.open {
+      display: block;
+      transform: translateX(0);
+    }
+
+    .extras-header {
+      padding: 10px 15px;
+      background: #f8f9fa;
+      border-bottom: 1px solid #dee2e6;
+      font-weight: bold;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
   </style>
 </head>
 
@@ -273,6 +304,7 @@
     <div class="control-btn" id="clear-selection-btn" title="Clear Selection" style="display: none;">✕</div>
     <input type="file" id="gpx-files" multiple accept=".gpx" style="display:none" />
     <div class="control-btn" id="upload-btn" title="Upload GPX">⬆</div>
+    <div class="control-btn" id="extras-btn" title="More">⋯</div>
   </div>
   
   <div id="side-panel">
@@ -294,6 +326,11 @@
     <div class="panel-summary" id="panel-summary">
       <!-- Summary info will be shown here -->
     </div>
+  </div>
+
+  <div id="extras-panel">
+    <div class="extras-header">Extra Features<span id="extras-close" style="cursor:pointer">×</span></div>
+    <div id="extras-content" class="panel-content"></div>
   </div>
 
   <div id="loading-indicator">
@@ -921,7 +958,7 @@
     }
 
     // Update map display to show only selected runs using vector tile filtering
-    function updateMapDisplay() {
+function updateMapDisplay() {
         if (!map.getLayer('runsVec')) return;
 
         let filter = null;
@@ -936,6 +973,52 @@
 
         map.setFilter('runsVec', filter);
     }
+
+    async function fetchLastActivity() {
+      try {
+        const resp = await fetch('/api/last_activity');
+        if (!resp.ok) return;
+        const data = await resp.json();
+        const container = document.getElementById('extras-content');
+        container.innerHTML = '';
+        if (!data || !data.id) {
+          container.textContent = 'No activities';
+          return;
+        }
+        const card = document.createElement('div');
+        card.className = 'run-card';
+        const startDate = new Date(data.metadata.start_time);
+        const distance = (data.metadata.distance * 0.000621371).toFixed(2);
+        const duration = formatDuration(data.metadata.duration);
+        const type = data.metadata.activity_type || 'other';
+        let icon = '❓';
+        if (type === 'run') icon = '🏃';
+        else if (type === 'bike' || type === 'biking') icon = '🚴';
+        else if (type === 'walk') icon = '🚶';
+        else if (type === 'hike') icon = '🥾';
+        card.innerHTML = `
+          <div class="run-date">${startDate.toLocaleDateString()} ${startDate.toLocaleTimeString()}</div>
+          <div class="run-stats"><span>📏 ${distance} mi</span><span>⏱️ ${duration}</span></div>
+          <div style="font-size:20px;margin-top:4px;">${icon}</div>`;
+        container.appendChild(card);
+      } catch (e) {
+        console.error('Failed to fetch last activity', e);
+      }
+    }
+
+    document.getElementById('extras-btn').addEventListener('click', () => {
+      const panel = document.getElementById('extras-panel');
+      if (panel.classList.contains('open')) {
+        panel.classList.remove('open');
+      } else {
+        panel.classList.add('open');
+        fetchLastActivity();
+      }
+    });
+
+    document.getElementById('extras-close').addEventListener('click', () => {
+      document.getElementById('extras-panel').classList.remove('open');
+    });
   </script>
 </body>
 


### PR DESCRIPTION
## Summary
- add bullet about extras panel
- implement `/api/last_activity` endpoint
- show Extras button on web/mobile to open new sidebar
- fetch latest activity and display as card

## Testing
- `python3 -m venv .venv && source .venv/bin/activate && pip install Flask gpxpy rtree` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687fc86ba2908321b08847ec2bf85cdd